### PR TITLE
Feat/#9 kakao login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,14 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // webflux 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // lombok 의존성 추가
+    implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,17 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+
+    // Lombok 의존성 추가
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // 테스트에서 Lombok 사용
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     // webflux 의존성 추가
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
-    // lombok 의존성 추가
-    implementation 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
 
 }
 

--- a/src/main/java/org/socialculture/platform/config/SecurityConfig.java
+++ b/src/main/java/org/socialculture/platform/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package org.socialculture.platform.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/member/naver").permitAll()
+                        .requestMatchers("/api/v1/member/kakao").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .httpBasic(Customizer.withDefaults())
+                .build();
+    }
+}

--- a/src/main/java/org/socialculture/platform/member/MemberRole.java
+++ b/src/main/java/org/socialculture/platform/member/MemberRole.java
@@ -1,0 +1,5 @@
+package org.socialculture.platform.member;
+
+public enum MemberRole {
+    USER, PADMIN, ADMIN
+}

--- a/src/main/java/org/socialculture/platform/member/SocialProvider.java
+++ b/src/main/java/org/socialculture/platform/member/SocialProvider.java
@@ -1,0 +1,5 @@
+package org.socialculture.platform.member;
+
+public enum SocialProvider {
+    LOCAL, NAVER, KAKAO
+}

--- a/src/main/java/org/socialculture/platform/member/entity/MemberEntity.java
+++ b/src/main/java/org/socialculture/platform/member/entity/MemberEntity.java
@@ -1,0 +1,62 @@
+package org.socialculture.platform.member.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.socialculture.platform.member.MemberRole;
+import org.socialculture.platform.member.SocialProvider;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member")
+@Getter
+@Setter
+public class MemberEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "email", unique = true, nullable = false)
+    private String email;
+
+    @Column(name = "password")
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false)
+    private SocialProvider provider;
+
+    @Column(name = "provider_id")
+    private String providerId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private MemberRole role;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/org/socialculture/platform/member/oauth/kakao/controller/KakaoLoginController.java
+++ b/src/main/java/org/socialculture/platform/member/oauth/kakao/controller/KakaoLoginController.java
@@ -1,0 +1,40 @@
+package org.socialculture.platform.member.oauth.kakao.controller;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+import org.socialculture.platform.member.oauth.kakao.service.KakaoService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Slf4j
+@RequestMapping("/api/v1/member/kakao")
+public class KakaoLoginController {
+
+    private final KakaoService kakaoService;
+
+    public KakaoLoginController(KakaoService kakaoService) {
+        this.kakaoService = kakaoService;
+    }
+
+    /**
+     * 클라이언트에서 카카오 로그인을 했을때 이메일 따옴
+     * @param code
+     * @return
+     * @throws JsonProcessingException
+     */
+    @GetMapping("/auth")
+    public ResponseEntity<?> callback(@RequestParam("code") String code)
+            throws JsonProcessingException {
+
+        String accessToken = kakaoService.getAccessToken(code);
+        String email = kakaoService.getUserInfo(accessToken);
+
+        log.info("accessToken = {}", accessToken);
+        log.info("email = {}", email);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/org/socialculture/platform/member/oauth/kakao/service/KakaoService.java
+++ b/src/main/java/org/socialculture/platform/member/oauth/kakao/service/KakaoService.java
@@ -1,0 +1,104 @@
+package org.socialculture.platform.member.oauth.kakao.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+public class KakaoService {
+
+    private final String clientId;
+    private final String redirectUri;
+    private final String clientSecret;
+
+    public KakaoService(@Value("${kakao.client_id}") String clientId,
+                        @Value("${kakao.redirect_uri}") String redirectUri,
+                        @Value("${kakao.client_secret}") String clientSecret
+                        ){
+        this.clientId = clientId;
+        this.redirectUri = redirectUri;
+        this.clientSecret = clientSecret;
+    }
+
+
+    /**
+     * 클라이언트에서 인가 코드 받아서 access_token 반환
+     * @param code
+     * @return access_token
+     * @throws JsonProcessingException
+     */
+    public String getAccessToken(String code) throws JsonProcessingException {
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://kauth.kakao.com")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE,
+                        "application/x-www-form-urlencoded;charset=utf-8")
+                .build();
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+        body.add("client_secret", clientSecret);
+
+        String responseBody = webClient.post()
+                .uri("/oauth/token")
+                .bodyValue(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                        Mono.error(new RuntimeException("Invalid request")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                        Mono.error(new RuntimeException("Server error")))
+                .bodyToMono(String.class)
+                .block();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        return jsonNode.get("access_token").asText();
+    }
+
+    /**
+     * accessToken을 이용하여 카카오에서 유저의 email 을 따온다.
+     * @param accessToken
+     * @return email
+     * @throws JsonProcessingException
+     */
+    public String getUserInfo(String accessToken) throws JsonProcessingException {
+        WebClient webClient = WebClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE,
+                        "application/x-www-form-urlencoded;charset=utf-8")
+                .build();
+
+        String responseBody = webClient.post()
+                .uri("/v2/user/me")
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError, clientResponse ->
+                        Mono.error(new RuntimeException("Invalid request")))
+                .onStatus(HttpStatusCode::is5xxServerError, clientResponse ->
+                        Mono.error(new RuntimeException("Server error")))
+                .bodyToMono(String.class)
+                .block();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(responseBody);
+
+        String email = jsonNode.get("kakao_account").get("email").asText();
+
+        return email;
+    }
+
+
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
카카오 소셜 로그인 기능을 구현하기 위해 클라이언트에서 인가코드를 받고 해당 인가코드로 카카오서버에서 accessToken을 받아옵니다
받아온 accessToken을 이용해서 카카오서버에서 사용자 이메일을 받아왔습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
[feat: 카카오 사용자 이메일 가져오기] 소셜 로그인 기능구현을 위해 사용자의 이메일을 카카오 서버에서 받아옵니다.
[feat: Member엔티티,provider,role 추가] 공통적으로 사용할 member entity 와 social provider, member role 을 추가하였습니다.
[feat: webflux 의존성 추가] WebClient 사용을 위해 의존성을 추가하였습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
MemberRole, SocialRole을 MemberEntity 안에 안넣고, 밖에 두었는데 이게 나을까요?
