### PR TITLE
[Refactor] : 내가 단 댓글만 수정/삭제 가능하게 로직 추가

### DIFF
--- a/src/main/java/org/socialculture/platform/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/socialculture/platform/comment/service/CommentServiceImpl.java
@@ -137,6 +137,7 @@ public class CommentServiceImpl implements CommentService {
         // 이메일로 멤버 찾기
         MemberEntity member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        //rElseThrow() 메서드는 Optional 안에 값이 있으면 그 값을 반환하고, 값이 없으면 지정된 예외를 던진다. 그래서 Optional객체가 벗겨져서 나오는 것
 
         log.info("Authenticated user email {}",email);
 
@@ -156,18 +157,27 @@ public class CommentServiceImpl implements CommentService {
     }
 
     /**
-     * 댓글 전체 조회
+     * 댓글 삭제
      * @author sunghyun0610
      * @param commentId
      * @return 공통 Response사용하여 deleteComment반환
      *
      */
-
     @Override
     public CommentDeleteResponse deleteComment(long commentId) {
         // 댓글이 존재하지 않을 경우 예외를 던지고, 존재할 경우 바로 삭제
         CommentEntity commentEntity = commentRepository.findById(commentId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getName();
+
+        MemberEntity member = memberRepository.findByEmail(email)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if(!member.equals(commentEntity.getMember())){
+            throw new GeneralException(ErrorStatus._COMMENT_NOT_AUTHORIZED);
+        }
 
         CommentDeleteResponse commentDeleteResponse = CommentDeleteResponse.from(commentEntity.getPerformance().getPerformanceId());
         commentEntity.recordDeletedAt(LocalDateTime.now());

--- a/src/main/java/org/socialculture/platform/global/apiResponse/exception/ErrorStatus.java
+++ b/src/main/java/org/socialculture/platform/global/apiResponse/exception/ErrorStatus.java
@@ -52,7 +52,9 @@ public enum ErrorStatus implements BaseErrorCode{
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE404", "공연 카테고리를 찾을 수 없습니다."),
 
     //댓글
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404","댓글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404","댓글을 찾을 수 없습니다."),
+    _COMMENT_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "COMMENT403", "댓글 수정 권한이 없습니다. 본인이 작성한 댓글만 수정할 수 있습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
jwt token에서 user정보를 추출해 댓글의 member필드와 비교해, 내가 단 댓글만 수정/삭제 가능하게하는 로직 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
[refactor] 내가쓴 댓글만 수정가능
[refactor] 내가쓴 댓글만 삭제가능

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
