### PR TITLE
feat:jwt토큰발급 수정, 멤버도메인 api 토큰사용으로 변경

### DIFF
--- a/src/main/java/org/socialculture/platform/config/SecurityConfig.java
+++ b/src/main/java/org/socialculture/platform/config/SecurityConfig.java
@@ -41,9 +41,12 @@ public class SecurityConfig {
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/members/authenticate").permitAll()
-                        .requestMatchers("/api/v1/members/register").permitAll()
-                        .requestMatchers("/api/v1/members/validate").permitAll()
+                        .requestMatchers("/api/v1/members/**").permitAll()
+                        .requestMatchers("/api/v1/members/categories/**").authenticated()
+
+//                        .requestMatchers("/api/v1/members/register").permitAll()
+//                        .requestMatchers("/api/v1/members/validate").permitAll()
+//                        .requestMatchers("/api/v1/members/oauth/**").permitAll()
 //                        .requestMatchers("/api/v1/members").permitAll()
                         .anyRequest().authenticated()
                                 // 다른 모든 요청은 인증 필요 (개발 중에는 일단 모두 허용 가능)

--- a/src/main/java/org/socialculture/platform/member/auth/service/AuthService.java
+++ b/src/main/java/org/socialculture/platform/member/auth/service/AuthService.java
@@ -1,7 +1,11 @@
 package org.socialculture.platform.member.auth.service;
 
+
+import org.socialculture.platform.member.auth.dto.TokenResponseDTO;
+
 public interface AuthService {
     boolean validateRefreshToken(String refreshToken);
     String createNewAccessToken(String refreshToken);
     void insertRefreshToken(String refreshToken);
+    TokenResponseDTO createTokenResponseForSocialMember(String email);
 }

--- a/src/main/java/org/socialculture/platform/member/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/socialculture/platform/member/auth/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package org.socialculture.platform.member.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.socialculture.platform.global.apiResponse.exception.ErrorStatus;
 import org.socialculture.platform.global.apiResponse.exception.GeneralException;
+import org.socialculture.platform.member.auth.dto.TokenResponseDTO;
 import org.socialculture.platform.member.entity.MemberEntity;
 import org.socialculture.platform.member.entity.RefreshTokenEntity;
 import org.socialculture.platform.member.auth.JwtTokenProvider;
@@ -10,11 +11,11 @@ import org.socialculture.platform.member.repository.MemberRepository;
 import org.socialculture.platform.member.repository.RefreshTokenRepository;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-
-import static org.socialculture.platform.global.apiResponse.exception.ErrorStatus.PERFORMANCE_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class AuthServiceImpl implements AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final CustomUserDetailsService customUserDetailsService;
 
     /**
      * 리프레시 토큰 유효성 검사
@@ -90,4 +92,34 @@ public class AuthServiceImpl implements AuthService {
 
         refreshTokenRepository.save(refreshTokenEntity);
     }
+
+    /**
+     * 소셜 사용자의 토큰발행을 위해 사용
+     * @param email
+     * @return
+     */
+    @Override
+    public TokenResponseDTO createTokenResponseForSocialMember(String email) {
+        memberRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("사용자가 존재하지 않습니다."));
+
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+
+        PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
+                userDetails, null, userDetails.getAuthorities()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        String accessToken = jwtTokenProvider.createAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.createRefreshToken(email);
+
+        insertRefreshToken(refreshToken);
+
+        String message = "액세스 토큰과 리프레시 토큰이 정상적으로 발급되었습니다.";
+        return new TokenResponseDTO(accessToken, refreshToken, message);
+    }
+
+
+
 }

--- a/src/main/java/org/socialculture/platform/member/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/org/socialculture/platform/member/auth/service/CustomUserDetailsService.java
@@ -2,6 +2,7 @@ package org.socialculture.platform.member.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.socialculture.platform.member.entity.MemberEntity;
+import org.socialculture.platform.member.entity.SocialProvider;
 import org.socialculture.platform.member.repository.MemberRepository;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -10,13 +11,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
+
     private final MemberRepository memberRepository;
 
     @Override
@@ -24,9 +25,15 @@ public class CustomUserDetailsService implements UserDetailsService {
         MemberEntity member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
 
-        // MemberRole에서 GrantedAuthority로 변환
+        // 소셜 로그인 사용자인지 확인
+        boolean isSocialLogin = member.getProvider() != SocialProvider.LOCAL;
+
+        // 권한 설정
         GrantedAuthority grantedAuthority = new SimpleGrantedAuthority(member.getRole().name());
 
-        return new User(member.getEmail(), member.getPassword(), List.of(grantedAuthority));
+        // 소셜 사용자일 경우 비밀번호를 빈 문자열로 처리하고, 일반 사용자는 실제 비밀번호로 설정
+        String password = isSocialLogin ? "" : member.getPassword();
+
+        return new User(member.getEmail(), password, List.of(grantedAuthority));
     }
 }

--- a/src/main/java/org/socialculture/platform/member/controller/MemberController.java
+++ b/src/main/java/org/socialculture/platform/member/controller/MemberController.java
@@ -11,6 +11,8 @@ import org.socialculture.platform.member.dto.request.MemberCategoryRequest;
 import org.socialculture.platform.member.dto.response.CategoryResponse;
 import org.socialculture.platform.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -66,12 +68,10 @@ public class MemberController {
      * @return 성공 200, 닉네임중복409 , 닉네임 형식안맞음400
      */
     @PatchMapping("/name/{name}")
-    public ResponseEntity<ApiResponse<Void>> updateNickName(@PathVariable String name){
-//        String jwt = token.substring(7); // Bearer 제거
-//        String email = jwtService.getUserIdFromToken(jwt);
-        String email = "test@gmail.com";
+    public ResponseEntity<ApiResponse<Void>> updateNickName(
+            @PathVariable String name, @AuthenticationPrincipal UserDetails userDetails){
 
-        memberService.updateName(email, name);
+        memberService.updateName(userDetails.getUsername(), name);
         return ApiResponse.onSuccess();
     }
 
@@ -82,16 +82,14 @@ public class MemberController {
      */
     @PostMapping("/categories")
     public ResponseEntity<ApiResponse<Void>> addFavoriteCategories(
-            @RequestBody MemberCategoryRequest memberCategoryRequest) {
+            @RequestBody MemberCategoryRequest memberCategoryRequest,
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-//        String jwt = token.substring(7); // Bearer 제거
-//        String email = jwtService.getUserIdFromToken(jwt);
         if(memberCategoryRequest.categories().size() > 3){
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
 
-        String email = "test@gmail.com";
-        memberService.memberAddCategory(memberCategoryRequest, email);
+        memberService.memberAddCategory(memberCategoryRequest, userDetails.getUsername());
         return ApiResponse.onSuccess();
     }
 
@@ -113,10 +111,9 @@ public class MemberController {
      * @return
      */
     @GetMapping("/categories/favorites")
-    public ResponseEntity<ApiResponse<List<CategoryResponse>>> getFavoriteCategories() {
-
-        // 임시로 토큰 처리
-        String email = "test@gmail.com";
+    public ResponseEntity<ApiResponse<List<CategoryResponse>>> getFavoriteCategories(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        String email = userDetails.getUsername();
         List<CategoryResponse> favoriteCategories = memberService.getFavoriteCategories(email);
         return ApiResponse.onSuccess(favoriteCategories);
     }
@@ -129,13 +126,14 @@ public class MemberController {
      */
     @PutMapping("/categories/favorites")
     public ResponseEntity<ApiResponse<Void>> updateFavoriteCategories(
-            @RequestBody MemberCategoryRequest memberCategoryRequest){
+            @RequestBody MemberCategoryRequest memberCategoryRequest,
+            @AuthenticationPrincipal UserDetails userDetails
+    ){
 
         if(memberCategoryRequest.categories().size() > 3){
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
-        String email = "test@gmail.com";
-        memberService.updateFavoriteCategories(memberCategoryRequest, email);
+        memberService.updateFavoriteCategories(memberCategoryRequest, userDetails.getUsername());
 
         return ApiResponse.onSuccess();
     }
@@ -143,6 +141,7 @@ public class MemberController {
 
 
     // 회원권한 수정
+
 
 
 }

--- a/src/main/java/org/socialculture/platform/member/oauth/common/controller/OauthController.java
+++ b/src/main/java/org/socialculture/platform/member/oauth/common/controller/OauthController.java
@@ -4,20 +4,29 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.socialculture.platform.global.apiResponse.ApiResponse;
 import org.socialculture.platform.global.apiResponse.exception.ErrorStatus;
 import org.socialculture.platform.global.apiResponse.exception.GeneralException;
+import org.socialculture.platform.member.auth.JwtFilter;
+import org.socialculture.platform.member.auth.JwtTokenProvider;
+import org.socialculture.platform.member.auth.dto.TokenResponseDTO;
+import org.socialculture.platform.member.auth.service.AuthService;
+import org.socialculture.platform.member.auth.service.CustomUserDetailsService;
 import org.socialculture.platform.member.dto.request.SocialRegisterRequest;
 import org.socialculture.platform.member.entity.SocialProvider;
+import org.socialculture.platform.member.oauth.common.dto.SocialLoginRequest;
 import org.socialculture.platform.member.oauth.common.dto.SocialMemberCheckDto;
 import org.socialculture.platform.member.oauth.common.dto.SocialMemberInfoDto;
 import org.socialculture.platform.member.oauth.common.service.SocialClient;
 import org.socialculture.platform.member.oauth.kakao.service.KakaoClient;
 import org.socialculture.platform.member.oauth.naver.service.NaverClient;
+import org.socialculture.platform.member.repository.MemberRepository;
 import org.socialculture.platform.member.service.MemberService;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 네이버,카카오 소셜 로그인 컨트롤러 통합
@@ -32,37 +41,42 @@ public class OauthController {
     private final MemberService memberService;
     private final KakaoClient kakaoClient;
     private final NaverClient naverClient;
+    private final AuthService authService;
+    private final MemberRepository memberRepository;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtTokenProvider jwtTokenProvider;
 
 
     /**
      * provider를 구분하여 각각의 client에서
      * 회원정보 얻고, 가입되어있는지 여부 체크 후
      * 로그인 or 회원가입 실행
-     *
      * @param provider
-     * @param code
-     * @param state
+     * @param socialLoginRequest
      * @param session
      * @return
      * @throws JsonProcessingException
      */
-    @GetMapping("/{provider}")
-    public ResponseEntity<ApiResponse<Void>> socialCallback(
+    @PostMapping("/{provider}")
+    public ResponseEntity<?> socialCallback(
             @PathVariable("provider") SocialProvider provider,
-            @RequestParam("code") String code,
-            @RequestParam(value = "state", required = false) String state,
+            @RequestBody SocialLoginRequest socialLoginRequest,
             HttpSession session) throws JsonProcessingException {
 
         SocialClient clientByProvider = getClientByProvider(provider);
 
         String accessToken = (provider == SocialProvider.NAVER) ?
-                clientByProvider.getAccessToken(code, state)
-                : clientByProvider.getAccessToken(code);
+                clientByProvider.getAccessToken(socialLoginRequest.code(),
+                        socialLoginRequest.state())
+                : clientByProvider.getAccessToken(socialLoginRequest.code());
         SocialMemberCheckDto memberInfo = clientByProvider.getMemberInfo(accessToken);
 
         if (memberService.isSocialMemberRegistered(memberInfo)) {
-            //TODO 소셜 사용자 로그인 진행(토큰 발행 추가)
-            return ApiResponse.onSuccess();
+            // 가입되어있으면 토큰 발급
+            TokenResponseDTO tokenResponseDTO = authService
+                    .createTokenResponseForSocialMember(memberInfo.email());
+
+            return createTokenResponse(tokenResponseDTO);
         }
         // 소셜 사용자 회원가입시 필요한 기본정보 세션에 저장
         session.setAttribute("providerId", memberInfo.providerId());
@@ -71,12 +85,9 @@ public class OauthController {
 
         session.setMaxInactiveInterval(600); // 임시 회원정보 세션 10분간 유지
 
-        // 리다이렉트를 사용하려면 ApiResponse를 못쓰는것인지 모르겠음
-//        throw new GeneralException(ErrorStatus.SOCIAL_NAME_REQUIRED);
         // 추후 클라이언트 서버의 주소가 변경될 경우 이부분 변경 필요
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .header("Location", "http://localhost:3000/nickname").build();
-
+        return ResponseEntity.ok("redirect nicknamePage");
+//        return ResponseEntity.status(HttpStatus.OK).body("redirect nicknamePage");
     }
 
 
@@ -89,7 +100,7 @@ public class OauthController {
      * @return
      */
     @PostMapping("/register")
-    public ResponseEntity<ApiResponse<Void>> register(@RequestBody SocialMemberInfoDto memberInfoDto,
+    public ResponseEntity<?> register(@RequestBody SocialMemberInfoDto memberInfoDto,
                                                       HttpSession session) {
 
         memberService.validateNameAndCheckDuplicate(memberInfoDto.name());
@@ -109,7 +120,8 @@ public class OauthController {
         );
 
         memberService.registerSocialMember(socialRegisterRequest, session);
-        return ApiResponse.onSuccess();
+        TokenResponseDTO tokenResponseDTO = authService.createTokenResponseForSocialMember(email);
+        return createTokenResponse(tokenResponseDTO);
     }
 
 
@@ -124,6 +136,18 @@ public class OauthController {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
     }
+
+    // 소셜 사용자 로그인 후 토큰 발급
+    private ResponseEntity<TokenResponseDTO> createTokenResponse(TokenResponseDTO tokenResponseDTO) {
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(JwtFilter.AUTHORIZATION_HEADER, "Bearer "
+                + tokenResponseDTO.getAccessToken());
+
+        return new ResponseEntity<>(tokenResponseDTO, httpHeaders, HttpStatus.OK);
+    }
+
+
 
 
 }

--- a/src/main/java/org/socialculture/platform/member/oauth/common/dto/SocialLoginRequest.java
+++ b/src/main/java/org/socialculture/platform/member/oauth/common/dto/SocialLoginRequest.java
@@ -1,0 +1,7 @@
+package org.socialculture.platform.member.oauth.common.dto;
+
+public record SocialLoginRequest(
+        String code,
+        String state
+) {
+}

--- a/src/main/java/org/socialculture/platform/member/oauth/naver/service/NaverClient.java
+++ b/src/main/java/org/socialculture/platform/member/oauth/naver/service/NaverClient.java
@@ -42,17 +42,6 @@ public class NaverClient implements SocialClient {
         this.restTemplate = restTemplate;
     }
 
-//    /**
-//     * 네이버 인가코드 요청 URL을 생성해 제공 (테스트를 위한 코드로, 원래는 프론트 코드임)
-//     * @return 인가코드 요청 URL
-//     */
-//    public String getLoginURL() {
-//        return "https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=" +
-//                clientId +
-//                "&redirect_uri=" +
-//                redirectURI;
-//    }
-
     /**
      * 인가코드로 네이버 API에 액세스 토큰 요청
      * @param code 인가코드


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
*소셜 사용자를 jwt 토큰 발급 과정을 추가하였습니다.
*기존 소셜 사용자 로그인과 회원가입 과정에서 리다이렉트 uri를 서버쪽으로 해두어 인가코드를 
서버에서 받아 서버에서 액세스 토큰을 가져왔는데 리다이렉트 uri를 클라이언트로 변경하여 인가코드를 프론트에서 얻어오는 로직으로 변경하였습니다.
