### PR TITLE
refactor : response에 댓글 상태도 반환

### DIFF
--- a/src/main/java/org/socialculture/platform/comment/dto/response/CommentDeleteResponse.java
+++ b/src/main/java/org/socialculture/platform/comment/dto/response/CommentDeleteResponse.java
@@ -1,7 +1,9 @@
 package org.socialculture.platform.comment.dto.response;
 
-public record CommentDeleteResponse(long performanceId) {
-    public static CommentDeleteResponse from(long performanceId){
-        return new CommentDeleteResponse(performanceId);
+import org.socialculture.platform.comment.entity.CommentStatus;
+
+public record CommentDeleteResponse(long performanceId, CommentStatus commentStatus) {
+    public static CommentDeleteResponse of(long performanceId,CommentStatus commentStatus){
+        return new CommentDeleteResponse(performanceId, commentStatus);
     }
 }

--- a/src/main/java/org/socialculture/platform/comment/service/CommentServiceImpl.java
+++ b/src/main/java/org/socialculture/platform/comment/service/CommentServiceImpl.java
@@ -179,7 +179,7 @@ public class CommentServiceImpl implements CommentService {
             throw new GeneralException(ErrorStatus._COMMENT_NOT_AUTHORIZED);
         }
 
-        CommentDeleteResponse commentDeleteResponse = CommentDeleteResponse.from(commentEntity.getPerformance().getPerformanceId());
+        CommentDeleteResponse commentDeleteResponse = CommentDeleteResponse.of(commentEntity.getPerformance().getPerformanceId(), commentEntity.getCommentStatus());
         commentEntity.recordDeletedAt(LocalDateTime.now());
         commentEntity.changeCommentStatus(CommentStatus.DELETED);
 


### PR DESCRIPTION

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
댓글 삭제 api response에 댓글상태 데이터도 반환해주기위한 간단한 PR입니다~~

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
