### PR TITLE
Feat/#75 role change

### DIFF
--- a/src/main/java/org/socialculture/platform/member/auth/controller/AuthController.java
+++ b/src/main/java/org/socialculture/platform/member/auth/controller/AuthController.java
@@ -61,7 +61,7 @@ public class AuthController {
 
         String message = "액세스 토큰과 리프레시 토큰이 정상적으로 발급되었습니다.";
         return new ResponseEntity<>(new TokenResponseDTO(accessToken, refreshToken, message,
-                memberEntity.getName()), httpHeaders, HttpStatus.OK);
+                memberEntity.getName(), memberEntity.isFirstLogin()), httpHeaders, HttpStatus.OK);
     }
 
 

--- a/src/main/java/org/socialculture/platform/member/auth/dto/TokenResponseDTO.java
+++ b/src/main/java/org/socialculture/platform/member/auth/dto/TokenResponseDTO.java
@@ -10,6 +10,7 @@ public class TokenResponseDTO {
     private String refreshToken;
     private String message;
     private String userName;
+    private boolean isFirstLogin;
 
     public TokenResponseDTO(String message) {
         this.message = message;

--- a/src/main/java/org/socialculture/platform/member/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/socialculture/platform/member/auth/service/AuthServiceImpl.java
@@ -115,7 +115,8 @@ public class AuthServiceImpl implements AuthService {
         insertRefreshToken(refreshToken);
 
         String message = "액세스 토큰과 리프레시 토큰이 정상적으로 발급되었습니다.";
-        return new TokenResponseDTO(accessToken, refreshToken, message, memberEntity.getName());
+        return new TokenResponseDTO(
+                accessToken, refreshToken, message, memberEntity.getName(),memberEntity.isFirstLogin());
     }
 
 

--- a/src/main/java/org/socialculture/platform/member/controller/MemberController.java
+++ b/src/main/java/org/socialculture/platform/member/controller/MemberController.java
@@ -29,6 +29,7 @@ public class MemberController {
 
     /**
      * 이메일 중복 체크
+     *
      * @return true면 중복x
      */
     @GetMapping("/validation/email/{email}")
@@ -39,6 +40,7 @@ public class MemberController {
 
     /**
      * 닉네임 중복 체크
+     *
      * @param name
      * @return true면 중복x
      */
@@ -51,6 +53,7 @@ public class MemberController {
 
     /**
      * 일반사용자 회원가입
+     *
      * @param localRegisterRequest
      * @return 성공 200ok
      */
@@ -64,13 +67,14 @@ public class MemberController {
 
     /**
      * 닉네임 변경
+     *
      * @param name
      * @param token
      * @return 성공 200, 닉네임중복409 , 닉네임 형식안맞음400
      */
     @PatchMapping("/name/{name}")
     public ResponseEntity<ApiResponse<Void>> updateNickName(
-            @PathVariable String name, @AuthenticationPrincipal UserDetails userDetails){
+            @PathVariable String name, @AuthenticationPrincipal UserDetails userDetails) {
 
         memberService.updateName(userDetails.getUsername(), name);
         return ApiResponse.onSuccess();
@@ -78,6 +82,7 @@ public class MemberController {
 
     /**
      * 사용자 선호 카테고리 등록
+     *
      * @param memberCategoryRequest
      * @return 성공 200, 카테고리 및 회원 못찾음 404
      */
@@ -86,7 +91,7 @@ public class MemberController {
             @RequestBody MemberCategoryRequest memberCategoryRequest,
             @AuthenticationPrincipal UserDetails userDetails) {
 
-        if(memberCategoryRequest.categories().size() > 3){
+        if (memberCategoryRequest.categories().size() > 3) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
 
@@ -97,6 +102,7 @@ public class MemberController {
 
     /**
      * 카테고리 전체 목록 조회
+     *
      * @return categoryId, nameKr, nameEn
      */
     @GetMapping("/categories")
@@ -108,6 +114,7 @@ public class MemberController {
 
     /**
      * 사용자 선호 카테고리 조회
+     *
      * @param token
      * @return
      */
@@ -122,6 +129,7 @@ public class MemberController {
 
     /**
      * 사용자 선호 카테고리 수정
+     *
      * @param memberCategoryRequest
      * @return
      */
@@ -129,9 +137,9 @@ public class MemberController {
     public ResponseEntity<ApiResponse<Void>> updateFavoriteCategories(
             @RequestBody MemberCategoryRequest memberCategoryRequest,
             @AuthenticationPrincipal UserDetails userDetails
-    ){
+    ) {
 
-        if(memberCategoryRequest.categories().size() > 3){
+        if (memberCategoryRequest.categories().size() > 3) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
         memberService.updateFavoriteCategories(memberCategoryRequest, userDetails.getUsername());
@@ -142,6 +150,7 @@ public class MemberController {
 
     /**
      * 사용자 정보 조회
+     *
      * @param userDetails
      * @return email, name, role
      */
@@ -150,5 +159,21 @@ public class MemberController {
             @AuthenticationPrincipal UserDetails userDetails) {
         String email = userDetails.getUsername();
         return ApiResponse.onSuccess(memberService.getMemberInfoByEmail(email));
+    }
+
+
+    /**
+     * 첫 로그인 시 첫 로그인 여부 변경
+     *
+     * @param userDetails
+     * @return
+     */
+    @PatchMapping("/first-login")
+    public ResponseEntity<ApiResponse<Void>> changeFirstLogin(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        String email = userDetails.getUsername();
+        memberService.changeFirstLogin(email);
+        return ApiResponse.onSuccess();
     }
 }

--- a/src/main/java/org/socialculture/platform/member/entity/MemberEntity.java
+++ b/src/main/java/org/socialculture/platform/member/entity/MemberEntity.java
@@ -38,6 +38,9 @@ public class MemberEntity extends BaseEntity {
     @Column(name = "name", unique = true, nullable = false)
     private String name;
 
+    @Column(name = "first_login", nullable = false)
+    private boolean isFirstLogin = true;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private MemberRole role;
@@ -55,6 +58,10 @@ public class MemberEntity extends BaseEntity {
 
     public void changeRole(MemberRole newRole) {
         this.role = newRole;
+    }
+
+    public void markFirstLoginComplete() {
+        this.isFirstLogin = false;
     }
 
 }

--- a/src/main/java/org/socialculture/platform/member/service/MemberService.java
+++ b/src/main/java/org/socialculture/platform/member/service/MemberService.java
@@ -49,4 +49,7 @@ public interface MemberService {
 
     // 공연관리자로 권한 변경
     void changeRoleToPadmin(String email);
+
+    // 첫로그인 여부 변경
+    void changeFirstLogin(String email);
 }

--- a/src/main/java/org/socialculture/platform/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/socialculture/platform/member/service/MemberServiceImpl.java
@@ -204,8 +204,8 @@ public class MemberServiceImpl implements MemberService {
     private void addCategories(MemberCategoryRequest memberCategoryRequest, MemberEntity memberEntity) {
         List<Long> categoryIds = memberCategoryRequest.categories();
         for (Long categoryId : categoryIds) {
-            CategoryEntity categoryEntity = categoryRepository.findByCategoryId(categoryId).orElseThrow(() ->
-                    new GeneralException(ErrorStatus.MEMBER_CATEGORY_NOT_FOUND));
+            CategoryEntity categoryEntity = categoryRepository.findByCategoryId(categoryId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_CATEGORY_NOT_FOUND));
 
             MemberCategoryEntity memberCategoryEntity = MemberCategoryEntity.builder()
                     .category(categoryEntity)
@@ -238,8 +238,8 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public List<CategoryResponse> getFavoriteCategories(String email) {
-        MemberEntity memberEntity = memberRepository.findByEmail(email).orElseThrow(() ->
-                new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        MemberEntity memberEntity = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         List<CategoryEntity> favoriteCategories = memberCategoryRepository
                 .findCategoriesByMemberId(memberEntity.getMemberId());
@@ -256,8 +256,8 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public MemberInfoResponse getMemberInfoByEmail(String email) {
-        MemberEntity memberEntity = memberRepository.findByEmail(email).orElseThrow(() ->
-                new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        MemberEntity memberEntity = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
         return MemberInfoResponse.fromEntity(memberEntity);
     }
 
@@ -274,6 +274,21 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         member.changeRole(MemberRole.ROLE_PADMIN);
+        memberRepository.save(member);
+    }
+
+
+    /**
+     * 사용자 첫 로그인 후 첫 로그인 여부 변경
+     *
+     * @param email
+     */
+    @Override
+    public void changeFirstLogin(String email) {
+        MemberEntity member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.markFirstLoginComplete();
         memberRepository.save(member);
     }
 }

--- a/src/main/java/org/socialculture/platform/member/service/MemberServiceImpl.java
+++ b/src/main/java/org/socialculture/platform/member/service/MemberServiceImpl.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-public class MemberServiceImpl implements MemberService{
+public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberValidatorService memberValidatorService;
@@ -42,6 +42,7 @@ public class MemberServiceImpl implements MemberService{
     /**
      * 일반 사용자 회원가입
      * 패스워드 암호화 하여 저장
+     *
      * @param localRegisterRequest
      */
     @Override
@@ -69,6 +70,7 @@ public class MemberServiceImpl implements MemberService{
      * 소셜 사용자가 가입되어있는지 확인
      * 가입되어 있지 않으면 회원가입 진행에 필요한 정보들
      * session에 저장
+     *
      * @param socialMemberCheckDto
      * @param session
      * @return true이면 가입되어있는 사용자, false면 가입되어있지 않는 사용자
@@ -79,8 +81,13 @@ public class MemberServiceImpl implements MemberService{
         Optional<MemberEntity> findMember = memberRepository.findByEmail(socialMemberCheckDto.email());
 
         return findMember.map(member -> {
+            if (member.getProviderId() == null) {
+                log.info("이메일이 이미 존재하지만 소셜 회원은 아닐때");
+                throw new GeneralException(ErrorStatus.EMAIL_DUPLICATE);
+            }
             boolean matchesProvider = member.getProviderId().equals(socialMemberCheckDto.providerId());
             if (!matchesProvider) {
+                log.info("이메일이 이미 존재하고 소셜 회원일때");
                 throw new GeneralException(ErrorStatus.SOCIAL_EMAIL_DUPLICATE);
             }
             return true;
@@ -90,12 +97,13 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 소셜 사용자의 닉네임 체크 후 회원가입
+     *
      * @param memberInfoDto
      * @param session
      */
     @Transactional
     @Override
-    public void  registerSocialMember(SocialRegisterRequest request, HttpSession session) {
+    public void registerSocialMember(SocialRegisterRequest request, HttpSession session) {
 
         validateEmailAndCheckDuplicate(request.email());
         MemberEntity memberEntity = request.toEntity();
@@ -107,6 +115,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 이메일 중복 확인(이메일 형식 검증도 같이확인)
+     *
      * @param email
      */
     @Override
@@ -121,6 +130,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 닉네임 중복 확인 (닉네임 형식 검증도 같이확인)
+     *
      * @param name
      */
     @Override
@@ -135,6 +145,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 닉네임 변경
+     *
      * @param email
      * @param name
      */
@@ -154,6 +165,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 사용자 선호 카테고리 추가
+     *
      * @param memberCategoryRequest
      * @param email
      */
@@ -169,6 +181,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 선호 카테고리 수정
+     *
      * @param memberCategoryRequest
      * @param email
      */
@@ -206,6 +219,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 카테고리 전체 목록 조회
+     *
      * @return categoryId, categoryName
      */
     @Override
@@ -218,6 +232,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 사용자 선호 카테고리 조회
+     *
      * @param email
      * @return 선호하는 카테고리 목록
      */
@@ -235,6 +250,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 사용자 정보 조회
+     *
      * @param email
      * @return email, name, role
      */
@@ -248,6 +264,7 @@ public class MemberServiceImpl implements MemberService{
 
     /**
      * 공연관리자로 권한 변경
+     *
      * @param email
      */
     @Override


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
소셜 사용자가 회원가입 시도시 만약 해당 소셜서비스에서 사용하는 이메일이 이미 db에 있을 경우 
기존에는 500에러가 응답되어 소셜 로그인이 실패했다는 에러메시지가 alert 됐는데 이것을 
409에러를 반환하여 구체적으로 중복된 이메일이 사용되었다는 에러메시지가 alert 될 수 있도록 하였습니다.

member entity에 최초 로그인 여부를 구분하는 칼럼을 추가하여 사용자가 회원가입후 첫 로그인을 했을때만 선호카테고리 수정화면으로 리다이렉트 될 수 있도록 하였습니다.

아래는 사용자의 첫 로그인을 구분하기 위한 다른 방법들인데 참고하시고 혹시 의견이 있으시면 코멘트 남겨주시면 감사하겠습니다!
1. 프론트 로컬 스토리지에 저장하여 첫 로그인인지 구분하기 -> 만약 사용자가 다른 브라우저로 접속하거나, 다른 기기로 접속했을경우 이를 구분할 수 없다고 판단하여 사용하지 않았습니다.

2. 로그 테이블을 만들어서 구분 -> 사용자가 로그인을 하거나 로그아웃 할때마다 로그테이블에 로그인,로그아웃, 접속한 ip등 정보를 저장, 만약 로그테이블에 해당 사용자의 기록이 없다면 첫번째 로그인으로 간주하는 방식인데 매 로그인과 로그아웃같은 이벤트발생시 db에 저장 하고, 로그인 할때마다 해당 테이블에 접근해서 조회를 하는건 지금처럼 로그인 내역으로 무언가 사용자의 활동시간이나 ip주소등의 정보를 이용하여 보안상의 기능을 제공하지않고 단순 첫번째 로그인을 구분하기 위한 용도로 사용하기에는 맞지않다고 생각하였습니다. (프로젝트에 추가기능으로 다른 ip주소로 접근했을때 안내를 해준다던지 하는 기능을 추가한다면 로그테이블을 사용해보는것도 좋을것같습니다!)
