### PR TITLE
Feat/#85 performance image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-
+    implementation 'commons-net:commons-net:3.9.0'
 
 }
 

--- a/src/main/java/org/socialculture/platform/global/apiResponse/exception/ErrorStatus.java
+++ b/src/main/java/org/socialculture/platform/global/apiResponse/exception/ErrorStatus.java
@@ -54,6 +54,10 @@ public enum ErrorStatus implements BaseErrorCode{
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE404", "공연 카테고리를 찾을 수 없습니다."),
     PERFORMANCE_NOT_ACCESSIBLE(HttpStatus.FORBIDDEN, "PERFORMANCE403", "권한이 없습니다."),
 
+    // 공연 이미지 등록 관련
+    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "IMAGE400", "지원하지 않는 이미지 파일 형식입니다"),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMAGE404", "이미지를 찾을 수 없습니다."),
+
     //댓글
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT404","댓글을 찾을 수 없습니다."),
     _COMMENT_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "COMMENT403", "댓글 수정 권한이 없습니다. 본인이 작성한 댓글만 수정할 수 있습니다.");

--- a/src/main/java/org/socialculture/platform/performance/controller/PerformanceController.java
+++ b/src/main/java/org/socialculture/platform/performance/controller/PerformanceController.java
@@ -1,7 +1,6 @@
 package org.socialculture.platform.performance.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.socialculture.platform.global.apiResponse.ApiResponse;
 import org.socialculture.platform.performance.dto.CategoryDto;
 import org.socialculture.platform.performance.dto.request.PerformanceRegisterRequest;
@@ -11,11 +10,14 @@ import org.socialculture.platform.performance.dto.response.PerformanceDetailResp
 import org.socialculture.platform.performance.dto.response.PerformanceListResponse;
 import org.socialculture.platform.performance.dto.response.PerformanceUpdateResponse;
 import org.socialculture.platform.performance.service.PerformanceService;
+import org.socialculture.platform.performance.service.ImageUploadService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -25,19 +27,21 @@ import java.util.List;
 public class PerformanceController {
 
     private final PerformanceService performanceService;
+    private final ImageUploadService imageService;
 
     /**
      * @author Icecoff22
      * @param registerPerformanceRequest
      * @return 200, 등록 완료 메세지
      */
-    @PostMapping
+    @PostMapping(consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
     public ResponseEntity<ApiResponse<PerformanceRegisterResponse>> registerPerformance(
             @AuthenticationPrincipal UserDetails userDetails,
-            @RequestBody PerformanceRegisterRequest registerPerformanceRequest
+            @RequestPart("performanceData") PerformanceRegisterRequest registerPerformanceRequest,
+            @RequestPart("imageFile") MultipartFile imageFile
     ) {
         PerformanceRegisterResponse performanceRegisterResponse =
-                performanceService.registerPerformance(userDetails.getUsername(), registerPerformanceRequest);
+                performanceService.registerPerformance(userDetails.getUsername(), registerPerformanceRequest, imageFile);
 
         return ApiResponse.onSuccess(
                 HttpStatus.CREATED,
@@ -124,7 +128,7 @@ public class PerformanceController {
     ) {
         return ApiResponse.onSuccess(performanceService.getMyPerformanceList(userDetails.getUsername(), page, size));
     }
-    
+
     @GetMapping("/categories")
     public ResponseEntity<ApiResponse<List<CategoryDto>>> getCategories() {
         return ApiResponse.onSuccess(performanceService.getCategoryList());

--- a/src/main/java/org/socialculture/platform/performance/controller/PerformanceController.java
+++ b/src/main/java/org/socialculture/platform/performance/controller/PerformanceController.java
@@ -38,7 +38,7 @@ public class PerformanceController {
     public ResponseEntity<ApiResponse<PerformanceRegisterResponse>> registerPerformance(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestPart("performanceData") PerformanceRegisterRequest registerPerformanceRequest,
-            @RequestPart("imageFile") MultipartFile imageFile
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile
     ) {
         PerformanceRegisterResponse performanceRegisterResponse =
                 performanceService.registerPerformance(userDetails.getUsername(), registerPerformanceRequest, imageFile);

--- a/src/main/java/org/socialculture/platform/performance/dto/request/PerformanceRegisterRequest.java
+++ b/src/main/java/org/socialculture/platform/performance/dto/request/PerformanceRegisterRequest.java
@@ -15,23 +15,12 @@ public record PerformanceRegisterRequest(
         LocalDateTime dateEndTime,
         String address,
         String imageUrl,
-        Integer price,
+        int price,
         String description,
-        Integer maxAudience,
+        int maxAudience,
         LocalDateTime startDate,
         List<String> categories
 ) {
-    public PerformanceRegisterRequest {
-        // price가 null이면 기본값으로 0을 설정
-        if (price == null) {
-            price = 0;
-        }
-        // maxAudience가 null이면 기본값으로 0을 설정
-        if (maxAudience == null) {
-            maxAudience = 0;
-        }
-    }
-
     public PerformanceEntity toEntity(PerformanceRegisterRequest performanceRegisterRequest) {
         return PerformanceEntity.builder()
                 .title(performanceRegisterRequest.title)
@@ -46,20 +35,5 @@ public record PerformanceRegisterRequest(
                 .startDate(performanceRegisterRequest.startDate)
                 .performanceStatus(PerformanceStatus.NOT_CONFIRMED)
                 .build();
-    }
-
-    public PerformanceRegisterRequest withImageUrl(String imageUrl) {
-        return new PerformanceRegisterRequest(
-                this.title,
-                this.dateStartTime,
-                this.dateEndTime,
-                this.address,
-                imageUrl, // 새로운 imageUrl 값
-                this.price,
-                this.description,
-                this.maxAudience,
-                this.startDate,
-                this.categories
-        );
     }
 }

--- a/src/main/java/org/socialculture/platform/performance/dto/request/PerformanceRegisterRequest.java
+++ b/src/main/java/org/socialculture/platform/performance/dto/request/PerformanceRegisterRequest.java
@@ -3,6 +3,7 @@ package org.socialculture.platform.performance.dto.request;
 import lombok.Builder;
 import org.socialculture.platform.performance.entity.PerformanceEntity;
 import org.socialculture.platform.performance.entity.PerformanceStatus;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,12 +15,23 @@ public record PerformanceRegisterRequest(
         LocalDateTime dateEndTime,
         String address,
         String imageUrl,
-        int price,
+        Integer price,
         String description,
-        int maxAudience,
+        Integer maxAudience,
         LocalDateTime startDate,
         List<String> categories
 ) {
+    public PerformanceRegisterRequest {
+        // price가 null이면 기본값으로 0을 설정
+        if (price == null) {
+            price = 0;
+        }
+        // maxAudience가 null이면 기본값으로 0을 설정
+        if (maxAudience == null) {
+            maxAudience = 0;
+        }
+    }
+
     public PerformanceEntity toEntity(PerformanceRegisterRequest performanceRegisterRequest) {
         return PerformanceEntity.builder()
                 .title(performanceRegisterRequest.title)
@@ -34,5 +46,20 @@ public record PerformanceRegisterRequest(
                 .startDate(performanceRegisterRequest.startDate)
                 .performanceStatus(PerformanceStatus.NOT_CONFIRMED)
                 .build();
+    }
+
+    public PerformanceRegisterRequest withImageUrl(String imageUrl) {
+        return new PerformanceRegisterRequest(
+                this.title,
+                this.dateStartTime,
+                this.dateEndTime,
+                this.address,
+                imageUrl, // 새로운 imageUrl 값
+                this.price,
+                this.description,
+                this.maxAudience,
+                this.startDate,
+                this.categories
+        );
     }
 }

--- a/src/main/java/org/socialculture/platform/performance/entity/PerformanceEntity.java
+++ b/src/main/java/org/socialculture/platform/performance/entity/PerformanceEntity.java
@@ -102,4 +102,8 @@ public class PerformanceEntity extends BaseEntity {
     public void updateDeleteAt() {
         this.recordDeletedAt(LocalDateTime.now());
     }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/org/socialculture/platform/performance/service/ImageUploadService.java
+++ b/src/main/java/org/socialculture/platform/performance/service/ImageUploadService.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -38,6 +39,7 @@ public class ImageUploadService {
     private String nginxBaseUrl;
 
     public String uploadFileToFTP(MultipartFile imageFile) {
+        if(Objects.isNull(imageFile)) return null;
 
         FTPClient ftpClient = null;
         try {

--- a/src/main/java/org/socialculture/platform/performance/service/ImageUploadService.java
+++ b/src/main/java/org/socialculture/platform/performance/service/ImageUploadService.java
@@ -1,0 +1,120 @@
+package org.socialculture.platform.performance.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.net.ftp.FTP;
+import org.apache.commons.net.ftp.FTPClient;
+import org.socialculture.platform.global.apiResponse.exception.ErrorStatus;
+import org.socialculture.platform.global.apiResponse.exception.GeneralException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+/**
+ * FTP 서버에 공연 이미지 등록 서비스
+ *
+ * @author ycjung
+ */
+@Service
+@Slf4j
+public class ImageUploadService {
+
+    @Value("${ftp.host}")
+    private String ftpHost;
+
+    @Value("${ftp.username}")
+    private String ftpUsername;
+
+    @Value("${ftp.password}")
+    private String ftpPassword;
+
+    @Value("${ftp.poster-path}") // 설정 파일에서 포스터 저장 경로를 가져옴
+    private String ftpPosterPath;
+
+    @Value("${nginx.server.base.url}") // Nginx 서버의 기본 URL 정보 가져오기
+    private String nginxBaseUrl;
+
+    public String uploadFileToFTP(MultipartFile imageFile) {
+
+        FTPClient ftpClient = null;
+        try {
+            ftpClient = connectToFtp();
+
+            // UUID 기반 고유 파일명 생성 및 경로 결정 (경로는 /upload/pfmPoster/UUID.확장자)
+            String uuidFileName = generateUuidFileName(imageFile.getOriginalFilename());
+            String imageUrl = buildImageUrl(uuidFileName); // /upload/pfmPoster/UUID.확장자
+
+            // 로그 추가: 파일 업로드 시작
+            log.debug("Starting FTP file upload. File: {}, UUID File Name: {}", imageFile.getOriginalFilename(), uuidFileName);
+
+            // FTP 서버에 파일 업로드
+            uploadToFtp(ftpClient, imageFile, uuidFileName);
+
+            // 로그 추가: 파일 업로드 성공
+            log.info("File upload to FTP server completed successfully. Image URL: {}", imageUrl);
+            return nginxBaseUrl + imageUrl;
+        } catch (IOException e) {
+            log.error("Error during FTP file upload. File: {}, Error: {}", imageFile.getOriginalFilename(), e.getMessage());
+            throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+        } finally {
+            closeFtpClient(ftpClient);
+        }
+
+
+    }
+
+    // FTP 클라이언트 연결 설정
+    private FTPClient connectToFtp() throws IOException {
+        FTPClient ftpClient = new FTPClient();
+        ftpClient.connect(ftpHost);
+        ftpClient.login(ftpUsername, ftpPassword);
+        ftpClient.enterLocalPassiveMode(); // 수동 모드 설정
+        ftpClient.setFileType(FTP.BINARY_FILE_TYPE); // 바이너리 전송 모드 설정
+        return ftpClient;
+    }
+
+    // FTP 클라이언트 종료
+    private void closeFtpClient(FTPClient ftpClient) {
+        if (ftpClient != null && ftpClient.isConnected()) {
+            try {
+                ftpClient.logout();
+                ftpClient.disconnect();
+            } catch (IOException ex) {
+                log.error("Error while disconnecting FTP client: {}", ex.getMessage(), ex);
+                throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    // FTP 업로드
+    private void uploadToFtp(FTPClient ftpClient, MultipartFile file, String fileName) throws IOException {
+        String remotePath = ftpPosterPath + fileName; // 포스터 경로 설정 (/upload/pfmPoster/UUID.확장자)
+        try (InputStream inputStream = file.getInputStream()) {
+            if (!ftpClient.storeFile(remotePath, inputStream)) {
+                String reply = ftpClient.getReplyString(); // FTP 서버 응답 로그
+                throw new RuntimeException("FTP 서버에 파일 업로드 실패: " + fileName + ". 응답: " + reply);
+            }
+        }
+    }
+
+    // UUID 기반 파일명 생성
+    private String generateUuidFileName(String originalFileName) {
+        String extension = getFileExtension(originalFileName); // 파일 확장자 추출
+        String uuid = UUID.randomUUID().toString(); // UUID 생성
+        return uuid + extension; // UUID + 확장자로 고유 파일명 생성
+    }
+
+    // 이미지 URL 생성 (IP나 포트 정보 없이 저장)
+    private String buildImageUrl(String fileName) {
+        return String.format("%s%s", ftpPosterPath, fileName); // /upload/pfmPoster/UUID.확장자 형식으로 경로 반환
+    }
+
+    // 파일 확장자 추출
+    private String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf('.');
+        return (dotIndex == -1) ? "" : fileName.substring(dotIndex);
+    }
+}

--- a/src/main/java/org/socialculture/platform/performance/service/ImageUploadService.java
+++ b/src/main/java/org/socialculture/platform/performance/service/ImageUploadService.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -114,9 +115,23 @@ public class ImageUploadService {
         return String.format("%s%s", ftpPosterPath, fileName); // /upload/pfmPoster/UUID.확장자 형식으로 경로 반환
     }
 
-    // 파일 확장자 추출
+    // 파일 확장자 추출 - 개선(확장자 필수, 이미지 필수)
     private String getFileExtension(String fileName) {
         int dotIndex = fileName.lastIndexOf('.');
-        return (dotIndex == -1) ? "" : fileName.substring(dotIndex);
+        if (dotIndex == -1) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_FORMAT);
+        }
+
+        String extension = fileName.substring(dotIndex + 1).toLowerCase(); // 소문자로 변환
+
+        // 허용되는 이미지 확장자 목록
+        List<String> allowedExtensions = List.of("jpg", "jpeg", "png", "gif", "bmp");
+
+        // 이미지 파일이 아닌 경우 예외 던지기
+        if (!allowedExtensions.contains(extension)) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_FORMAT);
+        }
+
+        return "." + extension;
     }
 }

--- a/src/main/java/org/socialculture/platform/performance/service/PerformanceService.java
+++ b/src/main/java/org/socialculture/platform/performance/service/PerformanceService.java
@@ -7,11 +7,12 @@ import org.socialculture.platform.performance.dto.request.PerformanceUpdateReque
 import org.socialculture.platform.performance.dto.response.PerformanceDetailResponse;
 import org.socialculture.platform.performance.dto.response.PerformanceListResponse;
 import org.socialculture.platform.performance.dto.response.PerformanceUpdateResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface PerformanceService {
-    PerformanceRegisterResponse registerPerformance(String email, PerformanceRegisterRequest performanceRegisterRequest);
+    PerformanceRegisterResponse registerPerformance(String email, PerformanceRegisterRequest performanceRegisterRequest, MultipartFile imageFile);
 
     PerformanceListResponse getPerformanceList(Integer page, Integer size, Long categoryId, String search, String email);
 

--- a/src/main/java/org/socialculture/platform/performance/service/PerformanceServiceImpl.java
+++ b/src/main/java/org/socialculture/platform/performance/service/PerformanceServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,15 +38,17 @@ public class PerformanceServiceImpl implements PerformanceService {
     private final PerformanceCategoryRepository performanceCategoryRepository;
     private final CategoryRepository categoryRepository;
     private final MemberRepository memberRepository;
-
+    private final ImageUploadService imageUploadService;
     //TODO : 사용자 넣기
     @Transactional
     @Override
-    public PerformanceRegisterResponse registerPerformance(String email, PerformanceRegisterRequest performanceRegisterRequest) {
+    public PerformanceRegisterResponse registerPerformance(String email, PerformanceRegisterRequest performanceRegisterRequest, MultipartFile imageFile) {
         MemberEntity memberEntity = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(MEMBER_NOT_FOUND));
         PerformanceEntity performanceEntity = performanceRegisterRequest.toEntity(performanceRegisterRequest);
         performanceEntity.updateMember(memberEntity);
+        String imageUrl = imageUploadService.uploadFileToFTP(imageFile);
+        performanceEntity.updateImageUrl(imageUrl);
         performanceEntity = performanceRepository.save(performanceEntity);
 
         List<CategoryEntity> categoryEntities = performanceCategorySave(performanceEntity, performanceRegisterRequest.categories());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,14 +5,20 @@ spring:
     username: ${HOME_USERNAME}
     password: ${HOME_PASSWORD}
 
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 50MB   # 파일 1개당 최대 크기
+      max-request-size: 50MB
+
   jpa:
-#    show-sql: true
+    #    show-sql: true
     properties:
       hibernate:
-#        format_sql: true
+    #        format_sql: true
     database: mysql
-#    hibernate:
-#      ddl-auto: create
+  #    hibernate:
+  #      ddl-auto: create
   kakao:
     client_id: ${KAKAO_CLIENT_ID}
     redirect_uri: ${KAKAO_REDIRECT_URI}
@@ -46,13 +52,19 @@ jwt:
   access:
     token:
       expiration: 1800000  # 액세스 토큰 유효 시간 (30분)
-#      expiration: 10000  # 액세스 토큰 유효 시간 (10초)
+  #      expiration: 10000  # 액세스 토큰 유효 시간 (10초)
   refresh:
     token:
       expiration: 604800000  # 리프레시 토큰 유효 시간 (7일)
 
+nginx:
+  server:
+    base:
+      url: ${NGINX_SERVER_BASE_URL}
 
-
-
-
-
+ftp:
+  host: ${FTP_HOST}
+  username: ${FTP_USERNAME}
+  password: ${FTP_PASSWORD}
+  poster-path: ${FTP_POSTER-PATH}
+  intro-path: ${FTP_INTRO-PATH}

--- a/src/test/java/org/socialculture/platform/performance/controller/PerformanceControllerTest.java
+++ b/src/test/java/org/socialculture/platform/performance/controller/PerformanceControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -100,7 +101,7 @@ public class PerformanceControllerTest {
                         )
                         .build();
 
-        given(performanceService.registerPerformance(email, performanceRegisterRequest))
+        given(performanceService.registerPerformance(email, performanceRegisterRequest, any(MultipartFile.class)))
                 .willReturn(performanceRegisterResponse);
 
         ResultActions result = this.mockMvc.perform(
@@ -212,8 +213,8 @@ public class PerformanceControllerTest {
                         getDocumentRequest(),
                         getDocumentResponse(),
                         queryParameters(
-                               parameterWithName("page").description("페이지 번호"),
-                               parameterWithName("size").description("페이지 사이즈")
+                                parameterWithName("page").description("페이지 번호"),
+                                parameterWithName("size").description("페이지 사이즈")
                         ),
                         responseFields(
                                 fieldWithPath("isSuccess").description("성공 여부"),


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
공연 등록 시에 이미지 정보를 FTP 서버에 저장하고,
Nginx 서버가 FTP 서버를 바라보도록 Web 서버를 구축하여 정적 이미지를 찾을 수 있도록 합니다.
(http 로 이미지 접근 가능)

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
feat : Nginx 로 FTP 서버 이미지 경로 매핑, FTP 서버 설정 추가
refactor : 공연 등록할 떄 이미지를 받으면 FTP 서버로 저장 및 정적 ImageUrl로 매핑 후 저장되도록 수정

-- 피드백 수정
refactor : 공연 등록할 때 이미지가 없다면 null 로 들어가게 처리 -> 프론트에서 null 에 대한 기본 이미지 제공 (예찬님 의견)
refactor :  이미지 확장자에 대한 정보만 FTP 에 저장할 수 있게 수정(승주님 의견), 잘못 들어오면 throw


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
